### PR TITLE
Apollo D2 stock DM changes

### DIFF
--- a/AlternateApollo/GameData/AlternateApollo/ApolloD2/ApolloD2.cfg
+++ b/AlternateApollo/GameData/AlternateApollo/ApolloD2/ApolloD2.cfg
@@ -6,12 +6,14 @@ PART
 	mesh = model.mu
 	scale = 1
 	rescaleFactor = 0.9375
-	node_stack_bottom = 0.0, -1.38, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_bottom = 0.0, -1.38, 0.0, 0.0, -1.0, 0.0, 2
 	node_stack_top = 0.0, 0.975	, 0.0, 0.0, 1.0, 0.0, 1
 
 	node_stack_para1 = 0.63604, 0.72176, 0.0, 0.0, 1.0, 0.0, 0
 	node_stack_para2 = -0.63604, 0.72176, 0.0, 0.0, 1.0, 0.0, 0
 
+	fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
+	sound_decoupler_fire = decouple	
 
 	TechRequired = commandModules
 	entryCost = 7600
@@ -213,7 +215,7 @@ MODULE
 		resourceName = MonoPropellant
 		resourceFlowMode = STAGE_PRIORITY_FLOW
 		runningEffectName = running
-		rcsEnabled = False
+		rcsEnabled = True
 		enableX = false
 		enableY = false
 		enableZ = false
@@ -228,7 +230,26 @@ MODULE
 		}
 	}
 
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 0.75
+		lossExp = -7500
+		lossConst = 0.1
+		pyrolysisLossFactor = 6000
+		ablationTempThresh = 500
+		reentryConductivity = 0.01
+		charMax = 1
+		charMin = 1
+	}
 
-
+	RESOURCE
+	{
+		name = Ablator
+		amount = 200
+		maxAmount = 200
+	}
 
 }

--- a/AlternateApollo/GameData/AlternateApollo/ApolloD2/RO_config/RO_ApolloD2.cfg
+++ b/AlternateApollo/GameData/AlternateApollo/ApolloD2/RO_config/RO_ApolloD2.cfg
@@ -23,19 +23,18 @@
 	
 	!RESOURCE,* {}
 
-	MODULE
+	@MODULE[ModuleAblator]
 	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 0.75
-		lossExp = -6000
-		lossConst = 0.2
-		pyrolysisLossFactor = 60000
-		ablationTempThresh = 500
-		reentryConductivity = 0.01
-		charMax = 1
-		charMin = 1
+		%ablativeResource = Ablator
+		%outputResource = CharredAblator
+		%outputMult = 0.75
+		%lossExp = -6000
+		%lossConst = 0.2
+		%pyrolysisLossFactor = 60000
+		%ablationTempThresh = 500
+		%reentryConductivity = 0.01
+		%charMax = 1
+		%charMin = 1
 	}
 	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
 	{


### PR DESCRIPTION
Apollo DM changes:
* change the bottom attach node to size 2, since it is about 2.5m size.
* add effects for the top-node (mission module) decoupler.
* change rcsEnabled to "True" so it's enabled by default.
* Add ModuleAblator, using stock values from the 2.5m heat shield
* Add 200 units Ablator resource.

RO MM patch changes:
* Change the section that adds ModuleAblator to a section that patches ModuleAblator so the values used for RO are the same.

I have a proposed change for the Propulsion Module as well, but I will submit that after this is closed.